### PR TITLE
Reduce image size via Multistage build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,4 +21,4 @@ jobs:
 
     - name: Test if Star Rating is inside JSON
       run:  |
-         docker exec osu.tools dotnet run -- difficulty 767046 -j | grep 'star_rating';
+         docker exec osu.tools dotnet PerformanceCalculator.dll difficulty 767046 -j | grep 'star_rating';

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
 
 ARG OSU_GIT
 ARG OSU_GIT_BRANCH
@@ -14,4 +14,10 @@ WORKDIR /project/osu-tools
 RUN /bin/bash -c ./UseLocalOsu.sh
 
 WORKDIR /project/osu-tools/PerformanceCalculator
-RUN dotnet build
+RUN dotnet build -o /osu.tools.build
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0
+WORKDIR /osu.tools.build
+COPY --from=base /osu.tools.build /osu.tools.build
+
+ENTRYPOINT /bin/sh

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker exec -it osu-tools sh
 It will run shell, which then you can use commands in `osu-tools`
 
 ```shell
-dotnet run -- difficulty 767046
+dotnet PerformanceCalculator.dll difficulty 767046
 ```
 ```
 ruleset: mania
@@ -57,7 +57,7 @@ OSU_TOOLS_GIT_BRANCH="impl-strain-json"
 Follow the same procedure above
 
 ```shell
-dotnet run -- difficulty 767046
+dotnet PerformanceCalculator.dll difficulty 767046
 ```
 
 As our osu branch inflates the SR, it should rise.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker compose up
 It will spin up a container `osu-tools`, which you can access via docker `exec`
 
 ```shell
-docker exec -it osu-tools sh
+docker exec -it osu.tools sh
 ```
 
 It will run shell, which then you can use commands in `osu-tools`


### PR DESCRIPTION
Using multiple stages, we can just pull the executable to `/`, which reduces the image size